### PR TITLE
add param type gen

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -331,7 +331,9 @@ AST *CodeGen::VisitParamList(ParamList *list, AST *obj)
 AST *CodeGen::VisitParam(Param *param, AST *obj)
 {
     param->identifier->Visit(this, nullptr);
-    ss << " ";
+    ss << ' ';
+    param->type->Visit(this, nullptr);
+    ss << ' ';
     return nullptr;
 }
 


### PR DESCRIPTION
type hint to params. Thought it wasn't necessary before but it is since obj and attrib type needs to be handled differently